### PR TITLE
feat!: add required message of the day

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,12 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+var motd string
 
 func PrintfFix(message string) {
 	fmt.Printf("fix: %s\n", message)
@@ -15,8 +21,18 @@ func PrintfBreakingChange(ty string, message string) {
 }
 
 func main() {
-	fmt.Println("Hello world!")
+	if motd == "" {
+		fmt.Println("Error: Message of the day cannot be empty.")
+		os.Exit(1)
+	}
+	fmt.Printf("%s\n", motd)
 	PrintfFeature("This is some more text!")
 	PrintfFeature("This is the third line of text")
 	PrintfFix("Fixed typo in third line of text")
+	PrintfBreakingChange("feat", "Add required message of the day")
+}
+
+func init() {
+	flag.StringVar(&motd, "motd", "", "Message of the day to print at startup")
+	flag.Parse()
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func PrintfBreakingChange(ty string, message string) {
 }
 
 func main() {
+	flag.Parse()
 	if motd == "" {
 		fmt.Println("Error: Message of the day cannot be empty.")
 		os.Exit(1)
@@ -34,5 +35,4 @@ func main() {
 
 func init() {
 	flag.StringVar(&motd, "motd", "", "Message of the day to print at startup")
-	flag.Parse()
 }


### PR DESCRIPTION
BREAKING CHANGE: A message of the day flag is now required to invoke the app correctly. Use `--motd="<your message>"` when running.